### PR TITLE
perf: add persistent HTTP client connection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "sqlite3", "~> 1.4"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 5.0"
 
+gem "net-http-persistent", "~> 4.0"
 gem "redis", "~> 5.0"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
     minitest (5.18.0)
     mock_redis (0.36.0)
       ruby2_keywords
+    net-http-persistent (4.0.2)
+      connection_pool (~> 2.2)
     net-imap (0.3.4)
       date
       net-protocol
@@ -177,6 +179,7 @@ DEPENDENCIES
   bulma-rails (~> 0.9.0)
   debug
   mock_redis (~> 0.36.0)
+  net-http-persistent (~> 4.0)
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.3)
   redis (~> 5.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,8 +14,8 @@ module ApplicationHelper
       raise ArgumentError.new("OpenWeather API key is missing")
     end
 
-    geocode_api = GeocoderAPI.new(api_key)
-    weather_api = WeatherAPI.new(api_key)
+    geocode_api = GeocoderAPI.new(HTTP_CLIENT, api_key)
+    weather_api = WeatherAPI.new(HTTP_CLIENT, api_key)
     Weather::WeatherService.new(REDIS, weather_api, geocode_api)
   end
 end

--- a/config/initializers/http_client.rb
+++ b/config/initializers/http_client.rb
@@ -1,0 +1,3 @@
+require "net/http/persistent"
+
+HTTP_CLIENT = Net::HTTP::Persistent.new(name: "weather-report")

--- a/lib/infra/geocoder.rb
+++ b/lib/infra/geocoder.rb
@@ -11,7 +11,8 @@ module Infra
     ##
     # Create an instance of the GeocoderAPI given an +api_key+ for
     # authorizing requests.
-    def initialize(api_key)
+    def initialize(client, api_key)
+      @client = client
       @api_key = api_key
     end
 
@@ -20,7 +21,7 @@ module Infra
     # (defaults to US), or raise an error.
     def geocode_from_zipcode(zipcode, country_code = "US")
       uri = URI("#{HOSTNAME}?zip=#{zipcode},#{country_code}&appid=#{@api_key}")
-      res = Net::HTTP.get_response(uri)
+      res = @client.request(uri)
       Infra.handle_response(res, GeocoderAPIError)
     end
   end

--- a/lib/infra/weather.rb
+++ b/lib/infra/weather.rb
@@ -17,7 +17,8 @@ module Infra
     ##
     # Create an instance of the WeatherAPI given an +api_key+ for
     # authorizing requests.
-    def initialize(api_key)
+    def initialize(client, api_key)
+      @client = client
       @api_key = api_key
     end
 
@@ -26,8 +27,11 @@ module Infra
     # +lon+. Note that units for results are specified in imperial
     # units. If the response is not successful, raise an error.
     def current_weather(lat, lon)
-      uri = URI("#{HOSTNAME}?lat=#{lat}&lon=#{lon}&units=imperial&appid=#{@api_key}")
-      res = Net::HTTP.get_response(uri)
+      uri =
+        URI(
+          "#{HOSTNAME}?lat=#{lat}&lon=#{lon}&units=imperial&appid=#{@api_key}"
+        )
+      res = @client.request(uri)
       Infra.handle_response(res, WeatherAPIError)
     end
   end


### PR DESCRIPTION
## Summary

Use a persistent HTTP client and create singleton instance via the application initializer. Connections are not shared across threads so should be safe to help reduce network overhead when communicating with external API services.